### PR TITLE
temporarily disable auto update for trunk

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,6 @@
 {
   "automerge-flathubbot-prs": true,
+  "disable-external-data-checker": true,
   "only-arches": [
     "x86_64"
   ]


### PR DESCRIPTION
It's not yet possible to download the exact binaries required by `trunk` automatically: https://github.com/thedodd/trunk/issues/316