### PR TITLE
Mark Wikit as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -3,5 +3,6 @@
   "disable-external-data-checker": true,
   "only-arches": [
     "x86_64"
-  ]
+  ],
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This application uses an old runtime that was marked as end-of-life (EOL) two years ago.

https://github.com/flathub/com.zhqli.wikit/issues/8